### PR TITLE
Use index instead of peer id

### DIFF
--- a/core-p2p/src/cita_handler.rs
+++ b/core-p2p/src/cita_handler.rs
@@ -14,7 +14,7 @@ use crate::custom_proto::{
     p2p_proto::{CustomProtocol, CustomProtocolSubstream},
 };
 
-type IdentifyBack = Arc<Mutex<Option<Box<Future<Item = (), Error = Error> + Send>>>>;
+type IdentifyBack = Arc<Mutex<Option<Box<dyn Future<Item = (), Error = Error> + Send>>>>;
 type DialUpgradeQueue<Substream> = Vec<(
     UpgradePurpose,
     Box<dyn Future<Item = FinalUpgrade<Substream>, Error = Error> + Send>,
@@ -52,6 +52,8 @@ pub enum CITAOutEvent<Substream> {
         /// Address the remote observes us as.
         observed_addr: Multiaddr,
     },
+    NeedReDial,
+    OverMaxConnection,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/core-p2p/src/lib.rs
+++ b/core-p2p/src/lib.rs
@@ -7,7 +7,7 @@ extern crate tokio;
 #[macro_use]
 extern crate log;
 
-pub use libp2p::{secio, Multiaddr, PeerId};
+pub use libp2p::{secio, Multiaddr};
 
 pub use cita_handler::{CITAInEvent, CITANodeHandler, CITAOutEvent};
 


### PR DESCRIPTION
1. Use index instead of peer id
2. Limit outbound and inbound up to 30
3. Add two handle events